### PR TITLE
Check that the category type a recipe has is valid

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -60,6 +60,9 @@ const REQUIRED_KEYS = [
         // Ensure required sections are in the yml file
         REQUIRED_KEYS.forEach(key => assert.ok(data[key]));
 
+        // Ensure category is valid
+        assert.ok(data.category in summary, `The category '${data.category}' for recipe '${data.title}' is invalid.`);
+
         // Save to summary Object
         if (!(data.sub_category in summary[data.category])) {
             summary[data.category][data.sub_category] = {};


### PR DESCRIPTION
This change adds a check to the build process for valid categories on each recipe. Before this change, if a recipe had an invalid category, we'd get an obscure exception that [looks like this](https://github.com/anoadragon453/recipes/runs/4020715370?check_suite_focus=true#step:5:8).

After this check, one would get:

```
% yarn build
yarn run v1.22.17
$ node index.mjs
AssertionError [ERR_ASSERTION]: The category 'Sides' for recipe 'Quick Mexican Rice' is invalid.
    at file:///home/user/code/recipes/index.mjs:65:9 {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '=='
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Which is slightly more helpful (if you know where to look).